### PR TITLE
Harden XMPP phase 1 and phase 2 security controls

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -105,6 +105,44 @@
         "default": true,
         "description": "Send read receipts (XEP-0333 chat markers) for incoming messages"
       },
+      "omemo": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable OMEMO encryption (XEP-0384)"
+          },
+          "deviceLabel": {
+            "type": "string",
+            "description": "Display label for this device in OMEMO device list"
+          },
+          "maxDevicesPerJid": {
+            "type": "number",
+            "default": 10,
+            "minimum": 1,
+            "maximum": 100,
+            "description": "Maximum devices per JID to encrypt for"
+          }
+        },
+        "description": "OMEMO encryption settings"
+      },
+      "media": {
+        "type": "object",
+        "properties": {
+          "allowFileUrls": {
+            "type": "boolean",
+            "default": false,
+            "description": "Allow file:// URLs for local media reads"
+          },
+          "allowedLocalPaths": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Allowlisted local roots for reading local media files"
+          }
+        },
+        "description": "Media/file read security settings"
+      },
       "accounts": {
         "type": "object",
         "additionalProperties": {
@@ -129,7 +167,24 @@
             "messagePrefix": { "type": "string", "description": "Inbound message prefix" },
             "heartbeatVisibility": { "type": "string", "enum": ["visible", "hidden"], "description": "Heartbeat visibility" },
             "groupSettings": { "type": "object", "description": "Per-group settings" },
-            "sendReadReceipts": { "type": "boolean", "default": true, "description": "Send read receipts (XEP-0333)" }
+            "sendReadReceipts": { "type": "boolean", "default": true, "description": "Send read receipts (XEP-0333)" },
+            "omemo": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean", "default": false, "description": "Enable OMEMO encryption (XEP-0384)" },
+                "deviceLabel": { "type": "string", "description": "Display label for this device in OMEMO device list" },
+                "maxDevicesPerJid": { "type": "number", "default": 10, "minimum": 1, "maximum": 100, "description": "Maximum devices per JID to encrypt for" }
+              },
+              "description": "OMEMO encryption settings"
+            },
+            "media": {
+              "type": "object",
+              "properties": {
+                "allowFileUrls": { "type": "boolean", "default": false, "description": "Allow file:// URLs for local media reads" },
+                "allowedLocalPaths": { "type": "array", "items": { "type": "string" }, "description": "Allowlisted local roots for local media files" }
+              },
+              "description": "Media/file read security settings"
+            }
           }
         },
         "description": "Multi-account configuration"

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -70,6 +70,16 @@
         "items": { "type": "string" },
         "description": "Allowed sender JIDs in groups (falls back to allowFrom)"
       },
+      "inviteAllowFrom": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Allowed inviter JIDs for auto-joining MUC invites (defaults to allowFrom)"
+      },
+      "allowSaslPlain": {
+        "type": "boolean",
+        "default": false,
+        "description": "Allow SASL PLAIN authentication fallback"
+      },
       "groups": {
         "type": "array",
         "items": { "type": "string" },
@@ -162,6 +172,8 @@
             "allowFrom": { "type": "array", "items": { "type": "string" }, "description": "Bot owner JIDs (always have direct chat access)" },
             "dmAllowlist": { "type": "array", "items": { "type": "string" }, "description": "DM allowlist JIDs (when dmPolicy is 'allowlist')" },
             "groupAllowFrom": { "type": "array", "items": { "type": "string" }, "description": "Allowed group senders" },
+            "inviteAllowFrom": { "type": "array", "items": { "type": "string" }, "description": "Allowed inviter JIDs for MUC auto-join" },
+            "allowSaslPlain": { "type": "boolean", "default": false, "description": "Allow SASL PLAIN authentication fallback" },
             "groups": { "type": "array", "items": { "type": "string" }, "description": "Group chat rooms to join" },
             "actions": { "type": "object", "description": "Action configuration" },
             "messagePrefix": { "type": "string", "description": "Inbound message prefix" },

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -47,7 +47,7 @@
         "type": "string",
         "enum": ["disabled", "open", "pairing", "allowlist"],
         "default": "open",
-        "description": "Guest direct chat policy: disabled (owners only), open (allow all), pairing (require approval), allowlist (only allowFrom)"
+        "description": "Guest direct chat policy: disabled (owners only), open (allow all), pairing (require approval), allowlist (owners + dmAllowlist only)"
       },
       "groupPolicy": {
         "type": "string",
@@ -119,7 +119,7 @@
             "name": { "type": "string", "description": "Account display name" },
             "enabled": { "type": "boolean", "default": true, "description": "Whether enabled" },
             "configWrites": { "type": "boolean", "default": true, "description": "Allow agent config modifications" },
-            "dmPolicy": { "type": "string", "enum": ["disabled", "open", "pairing", "allowlist"], "description": "Guest direct chat policy" },
+            "dmPolicy": { "type": "string", "enum": ["disabled", "open", "pairing", "allowlist"], "description": "Guest direct chat policy (allowlist uses owners + dmAllowlist)" },
             "groupPolicy": { "type": "string", "enum": ["open", "allowlist"], "description": "Group policy" },
             "allowFrom": { "type": "array", "items": { "type": "string" }, "description": "Bot owner JIDs (always have direct chat access)" },
             "dmAllowlist": { "type": "array", "items": { "type": "string" }, "description": "DM allowlist JIDs (when dmPolicy is 'allowlist')" },

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
 import type { XmppConfig, ResolvedXmppAccount } from "./types.js";
+import { isCredentialReference } from "./config-schema.js";
 
 /**
  * Get root XMPP config from OpenClaw config
@@ -120,6 +121,6 @@ export function listEnabledXmppAccounts(cfg: OpenClawConfig): ResolvedXmppAccoun
 export function isXmppConfigured(cfg: OpenClawConfig): boolean {
   return listXmppAccountIds(cfg).some((id) => {
     const account = resolveXmppAccount({ cfg, accountId: id });
-    return Boolean(account.config?.jid && account.config?.password);
+    return Boolean(account.config?.jid && account.config?.password && isCredentialReference(account.config.password));
   });
 }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -11,7 +11,7 @@ import type {
   ChannelAccountSnapshot,
   ThreadingToolContext,
 } from "./types.js";
-import { xmppChannelConfigSchema, bareJid } from "./config-schema.js";
+import { xmppChannelConfigSchema, bareJid, isCredentialReference } from "./config-schema.js";
 import { startXmppConnection } from "./monitor.js";
 import { sendXmppMessage, sendXmppMedia } from "./outbound.js";
 import { xmppOnboardingAdapter } from "./onboarding.js";
@@ -45,7 +45,7 @@ function getConfig(cfg: OpenClawConfig, accountId?: string): XmppConfig {
  */
 function isConfigured(cfg: OpenClawConfig, accountId?: string): boolean {
   const config = getConfig(cfg, accountId);
-  return Boolean(config.jid && config.password);
+  return Boolean(config.jid && config.password && isCredentialReference(config.password));
 }
 
 /**
@@ -171,14 +171,14 @@ export const xmppPlugin = {
     disabledReason: (): string => "disabled",
     
     isConfigured: (account: ResolvedXmppAccount): boolean =>
-      Boolean(account.config?.jid && account.config?.password),
+      Boolean(account.config?.jid && account.config?.password && isCredentialReference(account.config.password)),
     unconfiguredReason: (): string => "not configured",
     
     describeAccount: (account: ResolvedXmppAccount): XmppAccountDescriptor => ({
       accountId: account.accountId,
       name: account.config?.name || "XMPP",
       enabled: account.enabled,
-      configured: Boolean(account.config?.jid),
+      configured: Boolean(account.config?.jid && account.config?.password && isCredentialReference(account.config.password)),
       dmPolicy: account.config?.dmPolicy,
       allowFrom: account.config?.allowFrom,
     }),
@@ -417,12 +417,12 @@ export const xmppPlugin = {
           const url = new URL(mediaUrl);
           if (url.protocol === "file:") {
             const { readFileUrl } = await import("./file-read.js");
-            resolvedMedia = readFileUrl(mediaUrl, typedLog);
+            resolvedMedia = readFileUrl(mediaUrl, typedLog, { accountId: accountId ?? undefined, config });
           }
         } catch {
           // Not a valid URL — treat as local file path
           const { readLocalFile } = await import("./file-read.js");
-          const result = readLocalFile(mediaUrl, typedLog);
+          const result = readLocalFile(mediaUrl, typedLog, { accountId: accountId ?? undefined, config });
           if (!result) throw new Error(`File not found: ${mediaUrl}`);
           resolvedMedia = result;
         }
@@ -482,7 +482,7 @@ export const xmppPlugin = {
     },
     
     buildChannelSummary: async ({ account, snapshot }: { account: ResolvedXmppAccount; snapshot?: ChannelAccountSnapshot }) => ({
-      configured: Boolean(account.config?.jid && account.config?.password),
+      configured: Boolean(account.config?.jid && account.config?.password && isCredentialReference(account.config.password)),
       enabled: account.enabled,
       running: snapshot?.running ?? false,
       connected: snapshot?.connected ?? false,
@@ -496,7 +496,7 @@ export const xmppPlugin = {
       accountId: account.accountId,
       name: account.config?.name,
       enabled: account.enabled,
-      configured: Boolean(account.config?.jid && account.config?.password),
+      configured: Boolean(account.config?.jid && account.config?.password && isCredentialReference(account.config.password)),
       running: runtime?.running ?? false,
       connected: runtime?.connected ?? false,
       lastStartAt: runtime?.lastStartAt ?? null,

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -99,6 +99,11 @@ export const XmppAccountSchema = z.object({
 
   /** Allowed sender JIDs for groups */
   groupAllowFrom: z.array(z.string()).optional().describe("Allowed sender JIDs for groups (defaults to allowFrom, use * for all)"),
+  /** Allowed inviter JIDs for MUC auto-join */
+  inviteAllowFrom: z.array(z.string()).optional().describe("Allowed inviter JIDs for auto-joining MUC invites (defaults to allowFrom)"),
+
+  /** Allow SASL PLAIN fallback */
+  allowSaslPlain: z.boolean().optional().default(false).describe("Allow SASL PLAIN authentication fallback"),
 
   /** Group chat rooms to join */
   groups: z.array(z.string()).optional().describe("Group chat rooms to join on startup"),

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -12,6 +12,16 @@ export const XmppActionSchema = z.object({
 });
 
 /**
+ * Media security configuration schema
+ */
+export const XmppMediaSecurityConfigSchema = z.object({
+  /** Allow reading file:// URLs */
+  allowFileUrls: z.boolean().optional().default(false).describe("Allow file:// URLs for local media reads"),
+  /** Allowlisted local paths for media reads */
+  allowedLocalPaths: z.array(z.string()).optional().describe("Allowlisted local roots for reading media files"),
+});
+
+/**
  * Tool policy schema for group tool access control
  */
 export const ToolPolicySchema = z.object({
@@ -43,6 +53,8 @@ export const XmppOmemoConfigSchema = z.object({
   enabled: z.boolean().optional().default(false).describe("Enable OMEMO encryption (XEP-0384)"),
   /** Device label for this bot instance */
   deviceLabel: z.string().optional().describe("Display label for this device in OMEMO device list"),
+  /** Limit number of devices encrypted per JID */
+  maxDevicesPerJid: z.number().int().min(1).max(100).optional().default(10).describe("Maximum devices per JID to encrypt for"),
 });
 
 /**
@@ -108,6 +120,9 @@ export const XmppAccountSchema = z.object({
 
   /** OMEMO encryption configuration */
   omemo: XmppOmemoConfigSchema.optional().describe("OMEMO encryption settings (XEP-0384)"),
+
+  /** Media security configuration */
+  media: XmppMediaSecurityConfigSchema.optional().describe("Media/file read security settings"),
 });
 
 /**
@@ -151,4 +166,43 @@ export function extractUsername(jid: string): string {
  */
 export function bareJid(jid: string): string {
   return jid.split("/")[0];
+}
+
+/**
+ * Check if a password value is an indirect reference (not plaintext)
+ */
+export function isCredentialReference(value: string | undefined | null): boolean {
+  const raw = String(value ?? "").trim();
+  if (!raw) return false;
+  if (raw.startsWith("env:")) return true;
+  if (/^\$\{[A-Z0-9_]+\}$/.test(raw)) return true;
+  return false;
+}
+
+/**
+ * Resolve credential references from environment variables
+ */
+export function resolveCredentialReference(value: string): string {
+  const raw = value.trim();
+  if (raw.startsWith("env:")) {
+    const envName = raw.slice(4).trim();
+    if (!envName) {
+      throw new Error("Invalid env credential reference (missing variable name)");
+    }
+    const resolved = process.env[envName];
+    if (!resolved) {
+      throw new Error(`Missing environment variable for XMPP credential: ${envName}`);
+    }
+    return resolved;
+  }
+  const varMatch = raw.match(/^\$\{([A-Z0-9_]+)\}$/);
+  if (varMatch) {
+    const envName = varMatch[1];
+    const resolved = process.env[envName];
+    if (!resolved) {
+      throw new Error(`Missing environment variable for XMPP credential: ${envName}`);
+    }
+    return resolved;
+  }
+  throw new Error("XMPP password must be an environment reference (env:VAR or ${VAR})");
 }

--- a/src/file-read.ts
+++ b/src/file-read.ts
@@ -6,9 +6,11 @@
  */
 
 import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
 import { lookup as mimeLookup } from "mime-types";
 import type { Logger } from "./types.js";
+import type { XmppConfig } from "./types.js";
 
 export interface FetchedMedia {
   data: Buffer;
@@ -16,11 +18,48 @@ export interface FetchedMedia {
   filename: string;
 }
 
+interface LocalReadSecurityOptions {
+  accountId?: string;
+  config?: XmppConfig;
+  allowFileUrls?: boolean;
+}
+function canonicalizePath(target: string): string {
+  const resolved = path.resolve(target);
+  if (fs.existsSync(resolved)) {
+    try {
+      return fs.realpathSync(resolved);
+    } catch {
+      return resolved;
+    }
+  }
+  return resolved;
+}
+
+function resolveAllowedRoots(options?: LocalReadSecurityOptions): string[] {
+  const accountId = options?.accountId ?? "default";
+  const configured = options?.config?.media?.allowedLocalPaths ?? [];
+  const defaultRoot = path.join(os.homedir(), ".openclaw", "extensions", "xmpp", accountId, "media");
+  const roots = configured.length > 0 ? configured : [defaultRoot];
+  return roots.map((root) => canonicalizePath(root));
+}
+
+function isPathAllowed(candidate: string, allowedRoots: string[]): boolean {
+  const resolved = canonicalizePath(candidate);
+  for (const root of allowedRoots) {
+    const relative = path.relative(root, resolved);
+    if (relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Try to read a local file path, returning its data + metadata.
  * Returns null if the path is not found.
  */
-export function readLocalFile(urlOrPath: string, log?: Logger): FetchedMedia | null {
+export function readLocalFile(urlOrPath: string, log?: Logger, options?: LocalReadSecurityOptions): FetchedMedia | null {
+  const allowedRoots = resolveAllowedRoots(options);
   const possiblePaths = [
     urlOrPath,
     path.resolve(urlOrPath),
@@ -28,12 +67,17 @@ export function readLocalFile(urlOrPath: string, log?: Logger): FetchedMedia | n
 
   for (const filePath of possiblePaths) {
     try {
-      if (fs.existsSync(filePath)) {
-        log?.debug?.(`[XMPP] Reading local file: ${filePath}`);
-        const data = fs.readFileSync(filePath);
-        const ext = path.extname(filePath);
+      const resolved = canonicalizePath(filePath);
+      if (!isPathAllowed(resolved, allowedRoots)) {
+        log?.warn?.(`[XMPP] Blocked local file read outside allowlisted roots: ${resolved}`);
+        continue;
+      }
+      if (fs.existsSync(resolved)) {
+        log?.debug?.(`[XMPP] Reading local file: ${resolved}`);
+        const data = fs.readFileSync(resolved);
+        const ext = path.extname(resolved);
         const contentType = mimeLookup(ext) || "application/octet-stream";
-        const filename = path.basename(filePath);
+        const filename = path.basename(resolved);
         return { data, contentType, filename };
       }
     } catch (err) {
@@ -46,12 +90,22 @@ export function readLocalFile(urlOrPath: string, log?: Logger): FetchedMedia | n
 /**
  * Read a file:// URL, returning its data + metadata.
  */
-export function readFileUrl(fileUrl: string, log?: Logger): FetchedMedia {
+export function readFileUrl(fileUrl: string, log?: Logger, options?: LocalReadSecurityOptions): FetchedMedia {
+  const allowFileUrls = options?.allowFileUrls ?? options?.config?.media?.allowFileUrls ?? false;
+  if (!allowFileUrls) {
+    throw new Error("file:// URLs are disabled; set channels.xmpp.media.allowFileUrls=true to enable");
+  }
   const { pathname } = new URL(fileUrl);
-  log?.debug?.(`[XMPP] Reading file:// URL: ${pathname}`);
-  const data = fs.readFileSync(pathname);
-  const ext = path.extname(pathname);
+  const allowedRoots = resolveAllowedRoots(options);
+  const decodedPath = decodeURIComponent(pathname);
+  const resolved = canonicalizePath(decodedPath);
+  if (!isPathAllowed(resolved, allowedRoots)) {
+    throw new Error(`Blocked file:// read outside allowlisted roots: ${resolved}`);
+  }
+  log?.debug?.(`[XMPP] Reading file:// URL: ${resolved}`);
+  const data = fs.readFileSync(resolved);
+  const ext = path.extname(resolved);
   const contentType = mimeLookup(ext) || "application/octet-stream";
-  const filename = path.basename(pathname);
+  const filename = path.basename(resolved);
   return { data, contentType, filename };
 }

--- a/src/http-upload.ts
+++ b/src/http-upload.ts
@@ -18,6 +18,8 @@ import { iqId, extractErrorText, waitForIq } from "./xml-utils.js";
 import * as https from "https";
 import * as http from "http";
 import { URL } from "url";
+import { lookup } from "dns/promises";
+import * as net from "net";
 
 // XEP-0363 namespace
 export const NS_HTTP_UPLOAD = "urn:xmpp:http:upload:0";
@@ -400,35 +402,113 @@ export function parseOobData(stanza: Element): { url: string; description?: stri
  */
 export function downloadUrl(url: string, log?: Logger): Promise<{ data: Buffer; contentType: string; filename: string }> {
   return new Promise((resolve, reject) => {
-    const urlObj = new URL(url);
-    const httpModule = urlObj.protocol === "https:" ? https : http;
+    const fetch = async (target: string, redirectCount: number): Promise<{ data: Buffer; contentType: string; filename: string }> => {
+      const urlObj = new URL(target);
+      await ensurePublicTarget(urlObj);
+      const httpModule = urlObj.protocol === "https:" ? https : http;
 
-    httpModule.get(url, (res) => {
-      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-        downloadUrl(res.headers.location, log).then(resolve).catch(reject);
-        return;
-      }
+      return await new Promise((innerResolve, innerReject) => {
+        const req = httpModule.get(target, (res) => {
+          if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+            if (redirectCount >= MAX_REDIRECTS) {
+              innerReject(new Error("Too many redirects while downloading media"));
+              return;
+            }
+            const redirectedUrl = new URL(res.headers.location, urlObj).toString();
+            fetch(redirectedUrl, redirectCount + 1).then(innerResolve).catch(innerReject);
+            return;
+          }
 
-      if (res.statusCode && (res.statusCode < 200 || res.statusCode >= 300)) {
-        reject(new Error(`HTTP ${res.statusCode}`));
-        return;
-      }
+          if (res.statusCode && (res.statusCode < 200 || res.statusCode >= 300)) {
+            innerReject(new Error(`HTTP ${res.statusCode}`));
+            return;
+          }
 
-      const chunks: Buffer[] = [];
-      res.on("data", (chunk) => chunks.push(chunk));
-      res.on("end", () => {
-        const contentType = res.headers["content-type"] || "application/octet-stream";
-        const pathname = urlObj.pathname;
-        const filename = decodeURIComponent(pathname.split("/").pop() || "file");
-        resolve({ data: Buffer.concat(chunks), contentType, filename });
+          const chunks: Buffer[] = [];
+          let total = 0;
+          res.on("data", (chunk: Buffer) => {
+            total += chunk.length;
+            if (total > MAX_DOWNLOAD_BYTES) {
+              req.destroy(new Error(`Download exceeds max size (${MAX_DOWNLOAD_BYTES} bytes)`));
+              return;
+            }
+            chunks.push(chunk);
+          });
+          res.on("end", () => {
+            const contentType = res.headers["content-type"] || "application/octet-stream";
+            const pathname = urlObj.pathname;
+            const filename = decodeURIComponent(pathname.split("/").pop() || "file");
+            innerResolve({ data: Buffer.concat(chunks), contentType, filename });
+          });
+          res.on("error", innerReject);
+        });
+
+        req.setTimeout(DOWNLOAD_TIMEOUT_MS, () => {
+          req.destroy(new Error(`Media download timed out after ${DOWNLOAD_TIMEOUT_MS}ms`));
+        });
+        req.on("error", innerReject);
       });
-      res.on("error", reject);
-    }).on("error", reject);
+    };
+
+    fetch(url, 0).then(resolve).catch(reject);
   });
 }
 
 // Cache discovered upload services
 const uploadServiceCache = new Map<string, string>();
+
+const MAX_DOWNLOAD_BYTES = 25 * 1024 * 1024;
+const DOWNLOAD_TIMEOUT_MS = 15000;
+const MAX_REDIRECTS = 5;
+
+function isPrivateIpv4(ip: string): boolean {
+  const parts = ip.split(".").map((p) => Number.parseInt(p, 10));
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)) return true;
+  const [a, b] = parts;
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 0) return true;
+  return false;
+}
+
+function isPrivateIpv6(ip: string): boolean {
+  const normalized = ip.toLowerCase();
+  if (normalized === "::1") return true;
+  if (normalized.startsWith("fe80:")) return true; // link-local
+  if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true; // unique local
+  if (normalized === "::") return true;
+  return false;
+}
+
+async function ensurePublicTarget(urlObj: URL): Promise<void> {
+  if (urlObj.protocol !== "http:" && urlObj.protocol !== "https:") {
+    throw new Error(`Unsupported protocol for media download: ${urlObj.protocol}`);
+  }
+  const host = urlObj.hostname.trim().toLowerCase();
+  if (!host) throw new Error("Missing hostname in media URL");
+  if (host === "localhost") throw new Error("Blocked private hostname: localhost");
+
+  if (net.isIP(host) === 4 && isPrivateIpv4(host)) {
+    throw new Error(`Blocked private IPv4 target: ${host}`);
+  }
+  if (net.isIP(host) === 6 && isPrivateIpv6(host)) {
+    throw new Error(`Blocked private IPv6 target: ${host}`);
+  }
+
+  const resolved = await lookup(host, { all: true, verbatim: true });
+  if (!resolved.length) throw new Error(`Failed to resolve hostname: ${host}`);
+  for (const addr of resolved) {
+    if (addr.family === 4 && isPrivateIpv4(addr.address)) {
+      throw new Error(`Blocked private IPv4 resolution for ${host}: ${addr.address}`);
+    }
+    if (addr.family === 6 && isPrivateIpv6(addr.address)) {
+      throw new Error(`Blocked private IPv6 resolution for ${host}: ${addr.address}`);
+    }
+  }
+}
 
 /**
  * Get or discover the HTTP Upload service for a domain

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -23,6 +23,17 @@ function generateMessageId(): string {
   return randomUUID();
 }
 
+function sanitizeReactionMessageId(rawId: string): string | null {
+  const sanitized = String(rawId ?? "")
+    .normalize("NFC")
+    .replace(/[\u0000-\u001F\u007F]/g, "")
+    .trim();
+  if (!sanitized || sanitized.length > 256) {
+    return null;
+  }
+  return sanitized;
+}
+
 /**
  * Handle inbound message - validate allowlist and route to OpenClaw
  */
@@ -44,10 +55,17 @@ export async function handleInboundMessage(
 
   // Check allowlist - different logic for groups vs direct chats
   const senderBare = bareJid(message.from);
-  
-  // First check if sender is in allowFrom (owners) - they always have access
+  const senderNick = message.senderNick;
+  const roomJid = message.roomJid;
+  const groupRealSenderJid = (message.isGroup && senderNick && roomJid)
+    ? getOccupantRealJid(accountId, roomJid, senderNick)
+    : null;
+
+  // Check owner access (for groups this is based on real sender JID)
   const allowFromList = normalizeAllowFrom(config.allowFrom);
-  const isOwner = isSenderAllowed(allowFromList, senderBare);
+  const ownerIdentity = message.isGroup ? groupRealSenderJid : senderBare;
+  const isOwner = ownerIdentity ? isSenderAllowed(allowFromList, ownerIdentity) : false;
+  let commandAuthorized = false;
   
   if (message.isGroup) {
     // For groups: check groupPolicy first
@@ -56,37 +74,34 @@ export async function handleInboundMessage(
     if (groupPolicy === "open") {
       // Open policy - allow all group messages
       log?.debug?.(`[XMPP] Group message allowed (groupPolicy: open)`);
+      commandAuthorized = true;
     } else {
       // Allowlist policy - check groupAllowFrom (falls back to allowFrom)
       // For group messages, we need to check the sender's REAL JID, not the room JID
       // The occupant JID is room@conference/nick, so we need to look up the real JID
       const groupAllowList = normalizeAllowFrom(config.groupAllowFrom ?? config.allowFrom);
-      
-      // Try to get the sender's real JID from MUC occupant tracking
-      const senderNick = message.senderNick;
-      const roomJid = message.roomJid;
-      const realSenderJid = (senderNick && roomJid) 
-        ? getOccupantRealJid(accountId, roomJid, senderNick) 
-        : null;
-      
-      if (realSenderJid) {
+      if (isOwner) {
+        log?.debug?.(`[XMPP] Group message allowed (owner ${ownerIdentity})`);
+        commandAuthorized = true;
+      } else if (groupRealSenderJid) {
         // Non-anonymous room - check real JID against allowlist
-        if (!isSenderAllowed(groupAllowList, realSenderJid)) {
-          log?.debug?.(`[XMPP] Group message blocked: ${realSenderJid} (real JID for ${senderNick}) not in groupAllowFrom`);
+        if (!isSenderAllowed(groupAllowList, groupRealSenderJid)) {
+          log?.debug?.(`[XMPP] Group message blocked: ${groupRealSenderJid} (real JID for ${senderNick}) not in groupAllowFrom`);
           return;
         }
-        log?.debug?.(`[XMPP] Group message allowed: ${realSenderJid} in groupAllowFrom`);
+        log?.debug?.(`[XMPP] Group message allowed: ${groupRealSenderJid} in groupAllowFrom`);
+        commandAuthorized = true;
       } else {
-        // Anonymous/semi-anonymous room - can't verify real JID
-        // Allow message since the room is already configured in 'groups'
-        // If admin wants stricter control, they should use a non-anonymous room
-        log?.debug?.(`[XMPP] Group message allowed (anonymous room, cannot verify real JID for ${senderNick})`);
+        // Anonymous/semi-anonymous room - cannot verify sender under allowlist policy
+        log?.debug?.(`[XMPP] Group message blocked: cannot verify real JID for ${senderNick} in allowlist mode`);
+        return;
       }
     }
   } else {
     // For direct chats: owners (allowFrom) always have access
     if (isOwner) {
       log?.debug?.(`[XMPP] Direct chat allowed (owner ${senderBare} is in allowFrom)`);
+      commandAuthorized = true;
     } else {
       // Non-owners (guests): check dmPolicy
       const dmPolicy = config.dmPolicy ?? "open";
@@ -96,11 +111,13 @@ export async function handleInboundMessage(
         return;
       } else if (dmPolicy === "open") {
         log?.debug?.(`[XMPP] Direct chat allowed (dmPolicy: open)`);
+        commandAuthorized = true;
       } else if (dmPolicy === "allowlist") {
         // allowlist mode: check dmAllowlist (owners already passed above)
         const dmAllowList = normalizeAllowFrom(config.dmAllowlist);
         if (isSenderAllowed(dmAllowList, senderBare)) {
           log?.debug?.(`[XMPP] Direct chat allowed (dmPolicy: allowlist, ${senderBare} in dmAllowlist)`);
+          commandAuthorized = true;
         } else {
           log?.debug?.(`[XMPP] Direct chat blocked: guest ${senderBare} not in dmAllowlist`);
           return;
@@ -130,10 +147,6 @@ export async function handleInboundMessage(
     log?.debug?.(`[XMPP] Read receipts disabled, skipping for message ${message.id}`);
   }
 
-  // Command authorization: owners (allowFrom) always authorized,
-  // guests authorized only when dmPolicy allows them through
-  const commandAuthorized = isOwner || (config.dmPolicy ?? "open") === "open";
-  
   // Route to OpenClaw
   const route = rt.channel.routing.resolveAgentRoute({
     cfg,
@@ -489,7 +502,12 @@ export async function handleInboundReaction(params: {
 
   // For reactions, we need to check if the sender is allowed
   const allowFromList = normalizeAllowFrom(config.allowFrom);
-  const isOwner = isSenderAllowed(allowFromList, senderBare);
+  const groupRealSenderJid = (isGroup && senderNick && roomJid)
+    ? getOccupantRealJid(accountId, roomJid, senderNick)
+    : null;
+  const ownerIdentity = isGroup ? groupRealSenderJid : senderBare;
+  const isOwner = ownerIdentity ? isSenderAllowed(allowFromList, ownerIdentity) : false;
+  let commandAuthorized = false;
 
   if (isGroup) {
     // For groups: check groupPolicy first
@@ -497,40 +515,45 @@ export async function handleInboundReaction(params: {
 
     if (groupPolicy === "open") {
       log?.debug?.(`[XMPP] Group reaction allowed (groupPolicy: open)`);
+      commandAuthorized = true;
     } else {
       const groupAllowList = normalizeAllowFrom(config.groupAllowFrom ?? config.allowFrom);
-      
-      // Try to get the sender's real JID from MUC occupant tracking
-      const realSenderJid = (senderNick && roomJid) 
-        ? getOccupantRealJid(accountId, roomJid, senderNick) 
-        : null;
-      
-      if (realSenderJid) {
+      if (isOwner) {
+        log?.debug?.(`[XMPP] Group reaction allowed (owner ${ownerIdentity})`);
+        commandAuthorized = true;
+      } else if (groupRealSenderJid) {
         // Non-anonymous room - check real JID against allowlist
-        if (!isSenderAllowed(groupAllowList, realSenderJid)) {
-          log?.debug?.(`[XMPP] Group reaction blocked: ${realSenderJid} (real JID for ${senderNick}) not in groupAllowFrom`);
+        if (!isSenderAllowed(groupAllowList, groupRealSenderJid)) {
+          log?.debug?.(`[XMPP] Group reaction blocked: ${groupRealSenderJid} (real JID for ${senderNick}) not in groupAllowFrom`);
           return;
         }
-        log?.debug?.(`[XMPP] Group reaction allowed: ${realSenderJid} in groupAllowFrom`);
+        log?.debug?.(`[XMPP] Group reaction allowed: ${groupRealSenderJid} in groupAllowFrom`);
+        commandAuthorized = true;
       } else {
-        // Anonymous/semi-anonymous room - can't verify real JID
-        log?.debug?.(`[XMPP] Group reaction allowed (anonymous room, cannot verify real JID for ${senderNick})`);
+        // Anonymous/semi-anonymous room - cannot verify sender under allowlist policy
+        log?.debug?.(`[XMPP] Group reaction blocked: cannot verify real JID for ${senderNick} in allowlist mode`);
+        return;
       }
     }
   } else {
     // For direct chats: owners (allowFrom) always have access
-    if (!isOwner) {
+    if (isOwner) {
+      commandAuthorized = true;
+    } else {
       const dmPolicy = config.dmPolicy ?? "open";
 
       if (dmPolicy === "disabled") {
         log?.debug?.(`[XMPP] Direct chat reaction blocked (dmPolicy: disabled, guest ${senderBare})`);
         return;
+      } else if (dmPolicy === "open") {
+        commandAuthorized = true;
       } else if (dmPolicy === "allowlist") {
         const dmAllowList = normalizeAllowFrom(config.dmAllowlist);
         if (!isSenderAllowed(dmAllowList, senderBare)) {
           log?.debug?.(`[XMPP] Direct chat reaction blocked: guest ${senderBare} not in dmAllowlist`);
           return;
         }
+        commandAuthorized = true;
       }
     }
   }
@@ -542,11 +565,16 @@ export async function handleInboundReaction(params: {
 
   // Create a special body that the AI can understand as a reaction
   // Format: "[reaction] 👋 on your message"
-  const reactionText = `[reaction] ${emojis.join(" ")} on your message "${reactedMessageId}"`;
+  const safeReactedMessageId = sanitizeReactionMessageId(reactedMessageId);
+  if (!safeReactedMessageId) {
+    log?.warn?.(`[XMPP] Ignoring reaction from ${senderIdentity} with invalid reactedMessageId`);
+    return;
+  }
+  const reactionText = `[reaction] ${emojis.join(" ")} on your message \"${safeReactedMessageId}\"`;
   
   // DEBUG: Log what we're sending to the AI
   log?.info?.(`[XMPP] Reaction text for AI: ${reactionText}`);
-  log?.info?.(`[XMPP] Providing ReactedMessageId=${reactedMessageId} for AI to use when reacting back`);
+  log?.info?.(`[XMPP] Providing ReactedMessageId=${safeReactedMessageId} for AI to use when reacting back`);
 
   // Route to OpenClaw (same as regular messages)
   const route = rt.channel.routing.resolveAgentRoute({
@@ -582,10 +610,10 @@ export async function handleInboundReaction(params: {
     MessageSid: `reaction_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
     OriginatingChannel: "xmpp" as const,
     OriginatingTo: `xmpp:${isGroup ? roomJid : senderBare}`,
-    CommandAuthorized: isOwner || (config.dmPolicy ?? "open") === "open",
+    CommandAuthorized: commandAuthorized,
     // Include reaction-specific metadata
     ReactionEmojis: emojis,
-    ReactedMessageId: reactedMessageId,
+    ReactedMessageId: safeReactedMessageId,
     IsReaction: true,
   });
 

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -287,12 +287,12 @@ async function deliverReply(
         const url = new URL(mediaUrl);
         if (url.protocol === "file:") {
           const { readFileUrl } = await import("./file-read.js");
-          resolvedMedia = readFileUrl(mediaUrl, log);
+          resolvedMedia = readFileUrl(mediaUrl, log, { accountId, config });
         }
       } catch {
         // Not a valid URL — treat as local file path
         const { readLocalFile } = await import("./file-read.js");
-        const result = readLocalFile(mediaUrl, log);
+        const result = readLocalFile(mediaUrl, log, { accountId, config });
         if (!result) {
           log?.error?.(`[XMPP] File not found: ${mediaUrl}`);
           continue;

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -8,7 +8,7 @@
 import { client, xml } from "@xmpp/client";
 import type { Element } from "@xmpp/client";
 import type { XmppConfig, GatewayStartContext, XmppInboundMessage, Logger } from "./types.js";
-import { resolveServer, extractUsername, bareJid } from "./config-schema.js";
+import { resolveServer, extractUsername, bareJid, resolveCredentialReference } from "./config-schema.js";
 import { parsePepEvent, type PepItem } from "./pep.js";
 
 // Import from split modules
@@ -129,6 +129,7 @@ export async function startXmppConnection(ctx: GatewayStartContext): Promise<voi
 
   const server = resolveServer(config);
   const username = extractUsername(config.jid);
+  const resolvedPassword = resolveCredentialReference(config.password);
   
   // Generate unique resource per session to prevent connection conflicts on restart
   const sessionResource = config.resource ?? `openclaw-${generateSessionId()}`;
@@ -155,7 +156,7 @@ export async function startXmppConnection(ctx: GatewayStartContext): Promise<voi
     service: `xmpp://${server}:${config.port ?? 5222}`,
     domain: server,
     username,
-    password: config.password,
+    password: resolvedPassword,
     resource: sessionResource,
   });
 
@@ -238,7 +239,9 @@ export async function startXmppConnection(ctx: GatewayStartContext): Promise<voi
     // Initialize OMEMO if enabled
     if (config.omemo?.enabled) {
       try {
-        await initializeOmemo(accountId, config.jid, config.omemo.deviceLabel, log);
+        await initializeOmemo(accountId, config.jid, config.omemo.deviceLabel, log, {
+          maxDevicesPerJid: config.omemo.maxDevicesPerJid,
+        });
       } catch (err) {
         log?.error?.(`[${accountId}] OMEMO initialization failed: ${err instanceof Error ? err.message : String(err)}`);
         // Continue without OMEMO - non-fatal

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -7,6 +7,7 @@
 
 import { client, xml } from "@xmpp/client";
 import type { Element } from "@xmpp/client";
+import { createRequire } from "module";
 import type { XmppConfig, GatewayStartContext, XmppInboundMessage, Logger } from "./types.js";
 import { resolveServer, extractUsername, bareJid, resolveCredentialReference } from "./config-schema.js";
 import { parsePepEvent, type PepItem } from "./pep.js";
@@ -42,6 +43,76 @@ import {
   shutdownOmemo,
   handleDeviceListPepEvent,
 } from "./omemo/index.js";
+
+const require = createRequire(import.meta.url);
+const xmppXml = require("@xmpp/xml") as {
+  Parser: new () => {
+    on: (event: string, listener: (arg: unknown) => void) => void;
+    end: (input?: string) => void;
+  };
+};
+
+const NS_SCE = "urn:xmpp:sce:1";
+const NS_REACTIONS = "urn:xmpp:reactions:0";
+const MAX_REACTION_ID_LENGTH = 256;
+
+function parseXmlElement(xmlPayload: string): Element | null {
+  try {
+    const parser = new xmppXml.Parser();
+    let root: Element | null = null;
+    let failed = false;
+    parser.on("start", (element) => {
+      root = element as Element;
+    });
+    parser.on("end", (element) => {
+      root = element as Element;
+    });
+    parser.on("error", () => {
+      failed = true;
+    });
+    parser.end(xmlPayload);
+    if (failed) return null;
+    return root;
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeReactionMessageId(rawId: string | undefined): string | null {
+  const normalized = String(rawId ?? "")
+    .normalize("NFC")
+    .replace(/[\u0000-\u001F\u007F]/g, "")
+    .trim();
+  if (!normalized || normalized.length > MAX_REACTION_ID_LENGTH) {
+    return null;
+  }
+  return normalized;
+}
+
+function parseSceWrappedReaction(body: string): { reactedMessageId: string; emojis: string[] } | null {
+  if (!body.includes("<envelope") || !body.includes(NS_SCE)) {
+    return null;
+  }
+  const envelope = parseXmlElement(body);
+  if (!envelope) return null;
+  if (envelope.name !== "envelope") return null;
+  if (envelope.attrs?.xmlns !== NS_SCE) return null;
+
+  const content = envelope.getChild("content", NS_SCE) ?? envelope.getChild("content");
+  if (!content) return null;
+  const reactions = content.getChild("reactions", NS_REACTIONS) ?? content.getChild("reactions");
+  if (!reactions) return null;
+
+  const reactedMessageId = sanitizeReactionMessageId(reactions.attrs?.id);
+  if (!reactedMessageId) return null;
+
+  const emojis = reactions
+    .getChildren("reaction")
+    .map((reaction) => String(reaction.text?.() ?? "").trim())
+    .filter(Boolean);
+
+  return { reactedMessageId, emojis };
+}
 
 // =============================================================================
 // RE-EXPORTS for backward compatibility
@@ -152,13 +223,28 @@ export async function startXmppConnection(ctx: GatewayStartContext): Promise<voi
     log?.error?.(`[${accountId}] XMPP ERROR: setStatus function not provided by OpenClaw!`);
   }
 
+  const credentials = async (
+    authenticate: (creds: { username: string; password: string }) => Promise<void>,
+    mechanism?: string,
+  ) => {
+    const selected = String(mechanism ?? "").toUpperCase();
+    if (selected === "PLAIN" && config.allowSaslPlain !== true) {
+      throw new Error("Server selected SASL PLAIN; set channels.xmpp.allowSaslPlain=true to allow");
+    }
+    if (selected === "ANONYMOUS") {
+      throw new Error("Refusing SASL ANONYMOUS for authenticated XMPP account");
+    }
+    await authenticate({ username, password: resolvedPassword });
+  };
+
   const xmpp = client({
     service: `xmpp://${server}:${config.port ?? 5222}`,
     domain: server,
     username,
     password: resolvedPassword,
+    credentials,
     resource: sessionResource,
-  });
+  } as unknown as Parameters<typeof client>[0]);
 
   // Store client for outbound messaging
   activeClients.set(accountId, xmpp);
@@ -187,10 +273,10 @@ export async function startXmppConnection(ctx: GatewayStartContext): Promise<voi
   setupMessageHandler(xmpp, accountId, nickname, cfg, config, log, setStatus);
 
   // Setup presence handlers (subscriptions, MUC self-presence, errors)
-  setupPresenceHandlers(xmpp, accountId, log);
+  setupPresenceHandlers(xmpp, accountId, config, log);
 
   // Setup MUC invite handler
-  setupMucInviteHandler(xmpp, accountId, nickname, log);
+  setupMucInviteHandler(xmpp, accountId, nickname, config, log);
 
   // Setup IQ handlers (XEP-0092 version, XEP-0202 time)
   setupIqHandlers(xmpp, accountId, log);
@@ -445,9 +531,6 @@ function setupMessageHandler(
     const emeHint = stanza.getChild("encryption", "urn:xmpp:eme:0");
     const isOmemoStanza = hasOmemoEncryption || emeHint?.attrs?.name === "OMEMO";
     
-    // SCE (Stanza Content Encryption) namespace for parsing wrapped content
-    const NS_SCE = "urn:xmpp:sce:1";
-    
     if (isOmemoEnabled(accountId) && hasOmemoEncryption) {
       log?.debug?.(`[${accountId}] OMEMO encrypted message detected`);
       try {
@@ -457,58 +540,41 @@ function setupMessageHandler(
           log?.debug?.(`[${accountId}] OMEMO decryption successful`);
           
           // XEP-0444 + XEP-0420: Check if decrypted payload contains SCE-wrapped reactions
-          // The decrypted payload may be an SCE envelope containing <reactions> inside <content>
-          // Format: <envelope xmlns="urn:xmpp:sce:1"><content><reactions>...</reactions></content></envelope>
           try {
-            // Check if body is SCE envelope (starts with <envelope)
-            if (body.includes("<envelope") && body.includes("urn:xmpp:sce:1")) {
-              log?.debug?.(`[${accountId}] Detected SCE envelope in OMEMO payload`);
-              
-              // Parse the reactions from the SCE envelope using regex
-              // The structure is: <envelope ...><content><reactions ...>...</reactions></content></envelope>
-              const reactionsMatch = body.match(/<reactions\s+[^>]*id=["']([^"']+)["'][^>]*>.*?<\/reactions>/s);
-              if (reactionsMatch) {
-                // Extract the full reactions element
-                const reactionsXml = reactionsMatch[0];
-                const reactedMsgId = reactionsMatch[1];
-                
-                // Extract individual reactions
-                const emojiMatches = reactionsXml.match(/<reaction[^>]*>([^<]*)<\/reaction>/g) || [];
-                const emojis = emojiMatches.map(m => {
-                  const match = m.match(/<reaction[^>]*>([^<]*)<\/reaction>/);
-                  return match ? match[1] : "";
-                }).filter(Boolean);
-                
-                const senderBare = bareJid(from);
-                if (emojis.length > 0) {
-                  log?.info?.(`[${accountId}] XEP-0444 OMEMO-encrypted reaction from ${senderBare}: ${emojis.join(", ")} on message ${reactedMsgId}`);
-                } else {
-                  log?.info?.(`[${accountId}] XEP-0444 OMEMO-encrypted reaction removed by ${senderBare} on message ${reactedMsgId}`);
-                }
-                
-                // Determine if this is a groupchat or direct message
-                const roomJid = isGroupchat ? bareJid(from) : undefined;
-                const senderNick = isGroupchat ? from.split("/")[1] : undefined;
-                
-                // Route OMEMO-encrypted reaction to OpenClaw so the AI can see and process it
-                await handleInboundReaction({
-                  reactedMessageId: reactedMsgId || "",
-                  emojis,
-                  senderBare,
-                  senderFull: from,
-                  isGroup: isGroupchat,
-                  roomJid,
-                  senderNick,
-                  cfg,
-                  accountId,
-                  config,
-                  log,
-                  setStatus,
-                });
-                
-                // Reaction processed - don't continue with normal message handling
-                return;
+            const parsedReaction = parseSceWrappedReaction(body);
+            if (parsedReaction) {
+              log?.debug?.(`[${accountId}] Parsed SCE-wrapped reaction payload`);
+              const senderBare = bareJid(from);
+              if (parsedReaction.emojis.length > 0) {
+                log?.info?.(
+                  `[${accountId}] XEP-0444 OMEMO-encrypted reaction from ${senderBare}: ${parsedReaction.emojis.join(", ")} on message ${parsedReaction.reactedMessageId}`,
+                );
+              } else {
+                log?.info?.(
+                  `[${accountId}] XEP-0444 OMEMO-encrypted reaction removed by ${senderBare} on message ${parsedReaction.reactedMessageId}`,
+                );
               }
+
+              const roomJid = isGroupchat ? bareJid(from) : undefined;
+              const senderNick = isGroupchat ? from.split("/")[1] : undefined;
+
+              await handleInboundReaction({
+                reactedMessageId: parsedReaction.reactedMessageId,
+                emojis: parsedReaction.emojis,
+                senderBare,
+                senderFull: from,
+                isGroup: isGroupchat,
+                roomJid,
+                senderNick,
+                cfg,
+                accountId,
+                config,
+                log,
+                setStatus,
+              });
+
+              // Reaction processed - don't continue with normal message handling
+              return;
             }
           } catch (sceErr) {
             log?.warn?.(`[${accountId}] Failed to parse SCE envelope: ${sceErr}`);
@@ -537,7 +603,11 @@ function setupMessageHandler(
     // XEP-0444: Detect incoming reactions (reactions have no body)
     const reactionsEl = stanza.getChild("reactions", "urn:xmpp:reactions:0");
     if (reactionsEl) {
-      const reactedMsgId = reactionsEl.attrs.id;
+      const reactedMsgId = sanitizeReactionMessageId(reactionsEl.attrs.id);
+      if (!reactedMsgId) {
+        log?.warn?.(`[${accountId}] Ignoring reaction with missing/invalid message id from ${from}`);
+        return;
+      }
       const reactionChildren = reactionsEl.getChildren("reaction");
       const emojis = reactionChildren.map((r) => r.text?.() ?? "").filter(Boolean);
       const senderBare = bareJid(from);

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -3,6 +3,30 @@
  */
 
 import { bareJid } from "./config-schema.js";
+const JID_PREFIX_RE = /^(xmpp|jabber):/i;
+
+/**
+ * Normalize a bare JID for stable matching.
+ * Applies Unicode NFC normalization and lowercases the domain.
+ */
+export function normalizeXmppBareJid(jid: string): string {
+  const raw = String(jid ?? "").trim().replace(JID_PREFIX_RE, "");
+  if (!raw) {
+    throw new Error("Empty JID");
+  }
+  const bare = bareJid(raw).normalize("NFC");
+  const at = bare.indexOf("@");
+  if (at <= 0 || at >= bare.length - 1) {
+    throw new Error(`Invalid JID: ${jid}`);
+  }
+  const local = bare.slice(0, at).normalize("NFC");
+  const domain = bare.slice(at + 1).normalize("NFC").toLowerCase();
+  return `${local}@${domain}`;
+}
+
+function normalizeXmppBareJidForMatch(jid: string): string {
+  return normalizeXmppBareJid(jid).toLowerCase();
+}
 
 /**
  * Check if a string looks like an XMPP JID
@@ -57,16 +81,17 @@ export function isXmppMucJid(jid: string, mucDomains?: string[]): boolean {
 export function normalizeXmppTarget(raw: string | null | undefined): string | null {
   if (!raw) return null;
   
-  let target = raw.trim();
-  
-  // Strip xmpp: or jabber: prefix
-  target = target.replace(/^(xmpp|jabber):/i, "");
+  const target = raw.trim().replace(JID_PREFIX_RE, "");
   
   // Validate
   if (!looksLikeXmppJid(target)) return null;
   
-  // Return bare JID
-  return bareJid(target);
+  // Return canonical bare JID
+  try {
+    return normalizeXmppBareJid(target);
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -116,13 +141,22 @@ export function normalizeAllowFrom(list?: string[]): NormalizedAllowFrom {
   if (!list || list.length === 0) {
     return { entries: [], hasWildcard: false }; // Empty = allow none
   }
-  const entries = list
+  const rawEntries = list
     .map((jid) => String(jid ?? "").trim())
     .filter(Boolean)
-    .map((jid) => jid.replace(/^(xmpp|jabber):/i, ""))
-    .map((jid) => bareJid(jid).toLowerCase());
-  const hasWildcard = entries.includes("*");
-  return { entries: entries.filter((entry) => entry !== "*"), hasWildcard };
+    .map((jid) => jid.replace(JID_PREFIX_RE, ""));
+  const hasWildcard = rawEntries.includes("*");
+  const entries = rawEntries
+    .filter((entry) => entry !== "*")
+    .map((jid) => {
+      try {
+        return normalizeXmppBareJidForMatch(jid);
+      } catch {
+        return "";
+      }
+    })
+    .filter(Boolean);
+  return { entries, hasWildcard };
 }
 
 /**
@@ -131,6 +165,10 @@ export function normalizeAllowFrom(list?: string[]): NormalizedAllowFrom {
 export function isSenderAllowed(allowFrom: NormalizedAllowFrom, senderJid: string): boolean {
   if (allowFrom.hasWildcard) return true;
   if (!senderJid.trim()) return false;
-  const normalized = bareJid(senderJid).toLowerCase();
-  return allowFrom.entries.includes(normalized);
+  try {
+    const normalized = normalizeXmppBareJidForMatch(senderJid);
+    return allowFrom.entries.includes(normalized);
+  } catch {
+    return false;
+  }
 }

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -114,18 +114,23 @@ export interface NormalizedAllowFrom {
  */
 export function normalizeAllowFrom(list?: string[]): NormalizedAllowFrom {
   if (!list || list.length === 0) {
-    return { entries: [], hasWildcard: true }; // Empty = allow all
+    return { entries: [], hasWildcard: false }; // Empty = allow none
   }
-  const entries = list.map((jid) => bareJid(jid).toLowerCase());
+  const entries = list
+    .map((jid) => String(jid ?? "").trim())
+    .filter(Boolean)
+    .map((jid) => jid.replace(/^(xmpp|jabber):/i, ""))
+    .map((jid) => bareJid(jid).toLowerCase());
   const hasWildcard = entries.includes("*");
-  return { entries, hasWildcard };
+  return { entries: entries.filter((entry) => entry !== "*"), hasWildcard };
 }
 
 /**
  * Check if sender is allowed based on normalized allowFrom
  */
 export function isSenderAllowed(allowFrom: NormalizedAllowFrom, senderJid: string): boolean {
-  if (allowFrom.hasWildcard || allowFrom.entries.length === 0) return true;
+  if (allowFrom.hasWildcard) return true;
+  if (!senderJid.trim()) return false;
   const normalized = bareJid(senderJid).toLowerCase();
   return allowFrom.entries.includes(normalized);
 }

--- a/src/omemo/index.ts
+++ b/src/omemo/index.ts
@@ -73,6 +73,8 @@ const omemoStores = new Map<string, OmemoStore>();
 
 /** Accounts with OMEMO enabled */
 const omemoEnabled = new Set<string>();
+/** Per-account cap for devices encrypted per JID */
+const omemoMaxDevicesPerJid = new Map<string, number>();
 
 // =============================================================================
 // INITIALIZATION
@@ -90,7 +92,8 @@ export async function initializeOmemo(
   accountId: string,
   selfJid: string,
   deviceLabel?: string,
-  log?: Logger
+  log?: Logger,
+  options?: { maxDevicesPerJid?: number }
 ): Promise<OmemoStore> {
   try {
     // Create store
@@ -137,6 +140,7 @@ export async function initializeOmemo(
     // Track store
     omemoStores.set(accountId, store);
     omemoEnabled.add(accountId);
+    omemoMaxDevicesPerJid.set(accountId, Math.max(1, options?.maxDevicesPerJid ?? 10));
     
     log?.info?.(`[${accountId}] OMEMO initialized (device ${store.getDeviceId()})`);
     return store;
@@ -236,7 +240,12 @@ export async function shutdownOmemo(accountId: string, log?: Logger): Promise<vo
   
   omemoStores.delete(accountId);
   omemoEnabled.delete(accountId);
+  omemoMaxDevicesPerJid.delete(accountId);
   log?.debug?.(`[${accountId}] OMEMO shutdown`);
+}
+
+function getMaxDevicesPerJid(accountId: string): number {
+  return Math.max(1, omemoMaxDevicesPerJid.get(accountId) ?? 10);
 }
 
 // =============================================================================
@@ -612,14 +621,15 @@ export async function encryptOmemoMessage(
 
   try {
     // Fetch recipient's devices (uses cache if available)
-    const devices = await getDeviceList(accountId, recipientJid, false, log);
+    const maxDevicesPerJid = getMaxDevicesPerJid(accountId);
+    const devices = (await getDeviceList(accountId, recipientJid, false, log)).slice(0, maxDevicesPerJid);
     if (devices.length === 0) {
       log?.warn?.(`[${accountId}] No OMEMO devices for ${recipientJid}`);
       return null;
     }
 
     // Also include our own devices (except current one) for multi-device sync
-    const ownDevices = await getDeviceList(accountId, "", false, log);
+    const ownDevices = (await getDeviceList(accountId, "", false, log)).slice(0, maxDevicesPerJid);
     const ourDeviceId = store.getDeviceId();
     const otherOwnDevices = ownDevices.filter(d => d.id !== ourDeviceId);
 
@@ -773,10 +783,11 @@ export async function encryptMucOmemoMessage(
 
   try {
     // Collect all devices from all occupants
+    const maxDevicesPerJid = getMaxDevicesPerJid(accountId);
     const allDevices: Array<{ jid: string; deviceId: number }> = [];
     
     for (const jid of occupantJids) {
-      const devices = await getDeviceList(accountId, jid, false, log);
+      const devices = (await getDeviceList(accountId, jid, false, log)).slice(0, maxDevicesPerJid);
       for (const device of devices) {
         allDevices.push({ jid, deviceId: device.id });
       }
@@ -790,7 +801,7 @@ export async function encryptMucOmemoMessage(
     // Also include our own devices for multi-device sync
     // Unlike DMs, MUC messages are reflected back by the server, so we MUST
     // encrypt for our own device(s) to read the reflected message
-    const ownDevices = await getDeviceList(accountId, "", false, log);
+    const ownDevices = (await getDeviceList(accountId, "", false, log)).slice(0, maxDevicesPerJid);
     const ourDeviceId = store.getDeviceId();
     // For MUC, include ALL own devices including current one (for reflected messages)
     const ownDevicesToEncrypt = ownDevices;

--- a/src/omemo/persistence.ts
+++ b/src/omemo/persistence.ts
@@ -9,6 +9,7 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { randomBytes, createCipheriv, createDecipheriv, scryptSync } from "crypto";
 import type { OmemoStoreData } from "./types.js";
 import type { Logger } from "../types.js";
 
@@ -17,9 +18,20 @@ import type { Logger } from "../types.js";
 // =============================================================================
 
 const OMEMO_STORE_FILENAME = "xmpp-omemo.json";
+const OMEMO_KEY_FILENAME = "xmpp-omemo.key";
+const FILE_MODE_SECURE = 0o600;
 
 interface OmemoFileStore {
   accounts: Record<string, OmemoStoreData>;
+}
+
+interface EncryptedOmemoFileStore {
+  version: 1;
+  algorithm: "aes-256-gcm";
+  salt: string;
+  iv: string;
+  tag: string;
+  ciphertext: string;
 }
 
 export function getOmemoStorePath(): string {
@@ -27,12 +39,106 @@ export function getOmemoStorePath(): string {
   return path.join(homeDir, ".openclaw", "extensions", "xmpp", OMEMO_STORE_FILENAME);
 }
 
+function getOmemoKeyPath(): string {
+  const homeDir = os.homedir();
+  return path.join(homeDir, ".openclaw", "secrets", OMEMO_KEY_FILENAME);
+}
+
+function ensureSecureParentDir(filePath: string): void {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+}
+
+function writeFileAtomicSecure(filePath: string, content: string): void {
+  ensureSecureParentDir(filePath);
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tempPath, content, { encoding: "utf-8", mode: FILE_MODE_SECURE });
+  fs.renameSync(tempPath, filePath);
+  fs.chmodSync(filePath, FILE_MODE_SECURE);
+}
+
+function getOrCreateMasterKey(log?: Logger): Buffer {
+  const fromEnv = process.env.OPENCLAW_XMPP_KEYSTORE_KEY;
+  if (fromEnv && fromEnv.trim()) {
+    return Buffer.from(fromEnv.trim(), "utf-8");
+  }
+
+  const keyPath = getOmemoKeyPath();
+  ensureSecureParentDir(keyPath);
+  if (fs.existsSync(keyPath)) {
+    fs.chmodSync(keyPath, FILE_MODE_SECURE);
+    return fs.readFileSync(keyPath);
+  }
+
+  const generated = randomBytes(32);
+  fs.writeFileSync(keyPath, generated, { mode: FILE_MODE_SECURE });
+  fs.chmodSync(keyPath, FILE_MODE_SECURE);
+  log?.info?.(`[OMEMO] Created local keystore key at ${keyPath}`);
+  return generated;
+}
+
+function encryptStorePayload(payload: OmemoFileStore, log?: Logger): EncryptedOmemoFileStore {
+  const keyMaterial = getOrCreateMasterKey(log);
+  const salt = randomBytes(16);
+  const iv = randomBytes(12);
+  const key = scryptSync(keyMaterial, salt, 32);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const plaintext = Buffer.from(JSON.stringify(payload), "utf-8");
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return {
+    version: 1,
+    algorithm: "aes-256-gcm",
+    salt: salt.toString("base64"),
+    iv: iv.toString("base64"),
+    tag: tag.toString("base64"),
+    ciphertext: ciphertext.toString("base64"),
+  };
+}
+
+function decryptStorePayload(payload: EncryptedOmemoFileStore, log?: Logger): OmemoFileStore {
+  const keyMaterial = getOrCreateMasterKey(log);
+  const salt = Buffer.from(payload.salt, "base64");
+  const iv = Buffer.from(payload.iv, "base64");
+  const tag = Buffer.from(payload.tag, "base64");
+  const ciphertext = Buffer.from(payload.ciphertext, "base64");
+  const key = scryptSync(keyMaterial, salt, 32);
+  const decipher = createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(tag);
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return JSON.parse(plaintext.toString("utf-8")) as OmemoFileStore;
+}
+
+function isEncryptedStore(data: unknown): data is EncryptedOmemoFileStore {
+  if (!data || typeof data !== "object") return false;
+  const candidate = data as Partial<EncryptedOmemoFileStore>;
+  return candidate.version === 1
+    && candidate.algorithm === "aes-256-gcm"
+    && typeof candidate.salt === "string"
+    && typeof candidate.iv === "string"
+    && typeof candidate.tag === "string"
+    && typeof candidate.ciphertext === "string";
+}
+
 export function loadOmemoFileStore(log?: Logger): OmemoFileStore {
   try {
     const storePath = getOmemoStorePath();
     if (fs.existsSync(storePath)) {
+      fs.chmodSync(storePath, FILE_MODE_SECURE);
       const data = fs.readFileSync(storePath, "utf-8");
-      return JSON.parse(data) as OmemoFileStore;
+      const parsed = JSON.parse(data) as unknown;
+      if (isEncryptedStore(parsed)) {
+        return decryptStorePayload(parsed, log);
+      }
+      // Plaintext legacy format migration
+      if (parsed && typeof parsed === "object" && "accounts" in (parsed as Record<string, unknown>)) {
+        const legacy = parsed as OmemoFileStore;
+        saveOmemoFileStore(legacy, log);
+        log?.info?.("[OMEMO] Migrated plaintext OMEMO store to encrypted format");
+        return legacy;
+      }
     }
   } catch (err) {
     log?.warn?.(`[OMEMO] Failed to load persisted store: ${err instanceof Error ? err.message : String(err)}`);
@@ -43,11 +149,8 @@ export function loadOmemoFileStore(log?: Logger): OmemoFileStore {
 export function saveOmemoFileStore(store: OmemoFileStore, log?: Logger): void {
   try {
     const storePath = getOmemoStorePath();
-    const dir = path.dirname(storePath);
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
-    }
-    fs.writeFileSync(storePath, JSON.stringify(store, null, 2), "utf-8");
+    const encrypted = encryptStorePayload(store, log);
+    writeFileAtomicSecure(storePath, JSON.stringify(encrypted));
     log?.debug?.(`[OMEMO] Saved persisted store`);
   } catch (err) {
     log?.error?.(`[OMEMO] Failed to save persisted store: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/omemo/store.ts
+++ b/src/omemo/store.ts
@@ -86,6 +86,7 @@ export class OmemoStore {
   // Note: Signal library may store sessions as JSON strings OR ArrayBuffers depending on implementation
   private sessions = new Map<string, string | ArrayBuffer>();
   private identities = new Map<string, ArrayBuffer>();
+  private identityConflicts = new Set<string>();
 
   // Persistence callback
   private persistCallback?: () => Promise<void>;
@@ -390,11 +391,30 @@ export class OmemoStore {
    * Check if identity is trusted - ALWAYS TRUE (blind trust)
    */
   async isTrustedIdentity(
-    _identifier: string,
-    _identityKey: ArrayBuffer,
+    identifier: string,
+    identityKey: ArrayBuffer,
     _direction: number
   ): Promise<boolean> {
-    // ALWAYS TRUST - bot accepts any identity key
+    const existing = this.identities.get(identifier);
+    if (!existing) {
+      // Trust on first use (TOFU)
+      return true;
+    }
+
+    const existingArr = new Uint8Array(existing);
+    const newArr = new Uint8Array(identityKey);
+    if (existingArr.length !== newArr.length) {
+      this.identityConflicts.add(identifier);
+      this.log?.warn?.(`[OMEMO] Identity key changed for ${identifier} (length mismatch)`);
+      return false;
+    }
+    for (let i = 0; i < existingArr.length; i++) {
+      if (existingArr[i] !== newArr[i]) {
+        this.identityConflicts.add(identifier);
+        this.log?.warn?.(`[OMEMO] Identity key changed for ${identifier}`);
+        return false;
+      }
+    }
     return true;
   }
 
@@ -403,6 +423,24 @@ export class OmemoStore {
    */
   async saveIdentity(identifier: string, identityKey: ArrayBuffer): Promise<boolean> {
     const existing = this.identities.get(identifier);
+    if (existing) {
+      const existingArr = new Uint8Array(existing);
+      const newArr = new Uint8Array(identityKey);
+      let changed = existingArr.length !== newArr.length;
+      if (!changed) {
+        for (let i = 0; i < existingArr.length; i++) {
+          if (existingArr[i] !== newArr[i]) {
+            changed = true;
+            break;
+          }
+        }
+      }
+      if (changed) {
+        this.identityConflicts.add(identifier);
+        this.log?.warn?.(`[OMEMO] Refusing to overwrite identity for ${identifier}; manual trust reset required`);
+        return true;
+      }
+    }
     this.identities.set(identifier, identityKey);
     await this.persist();
 

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -2,7 +2,7 @@ import type { OpenClawConfig, RuntimeEnv, WizardPrompter } from "openclaw/plugin
 import { formatDocsLink, DEFAULT_ACCOUNT_ID, normalizeAccountId, promptAccountId } from "openclaw/plugin-sdk";
 import type { ChannelOnboardingAdapter, ChannelOnboardingStatus, ChannelOnboardingResult } from "./types.js";
 import { listXmppAccountIds, resolveDefaultXmppAccountId, resolveXmppAccount } from "./accounts.js";
-import { bareJid } from "./config-schema.js";
+import { bareJid, isCredentialReference } from "./config-schema.js";
 
 const channel = "xmpp" as const;
 
@@ -57,12 +57,16 @@ async function promptXmppCredentials(
     },
   });
 
-  // Note: WizardPrompter doesn't have a password method, use text instead
-  const password = await prompter.text({
-    message: "XMPP password",
+  const passwordRef = await prompter.text({
+    message: "XMPP password reference (env:VAR or ${VAR})",
+    placeholder: "env:XMPP_PASSWORD",
+    initialValue: existing?.config?.password,
     validate: (value) => {
       const raw = String(value ?? "").trim();
-      if (!raw) return "Password is required";
+      if (!raw) return "Password reference is required";
+      if (!isCredentialReference(raw)) {
+        return "Use env:VAR or ${VAR}; plaintext passwords are not allowed";
+      }
       return undefined;
     },
   });
@@ -75,7 +79,7 @@ async function promptXmppCredentials(
 
   const updates: Record<string, unknown> = {
     jid: jid.trim(),
-    password: password.trim(),
+    password: passwordRef.trim(),
   };
 
   if (server?.trim()) {
@@ -219,7 +223,7 @@ export const xmppOnboardingAdapter: ChannelOnboardingAdapter = {
     const defaultAccountId = resolveDefaultXmppAccountId(cfg);
     const accountId = overrideId ? normalizeAccountId(overrideId) : defaultAccountId;
     const account = resolveXmppAccount({ cfg, accountId });
-    const configured = Boolean(account?.config?.jid && account?.config?.password);
+    const configured = Boolean(account?.config?.jid && account?.config?.password && isCredentialReference(account.config.password));
     const accountLabel = accountId === DEFAULT_ACCOUNT_ID ? "default" : accountId;
 
     return {

--- a/src/rooms.ts
+++ b/src/rooms.ts
@@ -25,6 +25,7 @@ import {
 // =============================================================================
 
 const ROOMS_STORE_FILENAME = "xmpp-rooms.json";
+const FILE_MODE_SECURE = 0o600;
 
 interface RoomsStore {
   rooms: Record<string, string[]>; // accountId -> room JIDs
@@ -39,6 +40,7 @@ function loadPersistedRooms(log?: Logger): RoomsStore {
   try {
     const storePath = getRoomsStorePath();
     if (fs.existsSync(storePath)) {
+      fs.chmodSync(storePath, FILE_MODE_SECURE);
       const data = fs.readFileSync(storePath, "utf-8");
       return JSON.parse(data) as RoomsStore;
     }
@@ -53,9 +55,12 @@ function savePersistedRooms(store: RoomsStore, log?: Logger): void {
     const storePath = getRoomsStorePath();
     const dir = path.dirname(storePath);
     if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
+      fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
     }
-    fs.writeFileSync(storePath, JSON.stringify(store, null, 2), "utf-8");
+    const tempPath = `${storePath}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(tempPath, JSON.stringify(store, null, 2), { encoding: "utf-8", mode: FILE_MODE_SECURE });
+    fs.renameSync(tempPath, storePath);
+    fs.chmodSync(storePath, FILE_MODE_SECURE);
     log?.debug?.(`[XMPP] Saved persisted rooms`);
   } catch (err) {
     log?.error?.(`[XMPP] Failed to save persisted rooms: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/stanza-handlers.ts
+++ b/src/stanza-handlers.ts
@@ -9,7 +9,8 @@ import { xml } from "@xmpp/client";
 import type { Element } from "@xmpp/client";
 import type { client } from "@xmpp/client";
 import { bareJid } from "./config-schema.js";
-import type { Logger } from "./types.js";
+import { normalizeAllowFrom, isSenderAllowed } from "./normalize.js";
+import type { Logger, XmppConfig } from "./types.js";
 import { goneRooms, pendingMucJoins } from "./state.js";
 import { removePersistedRoom, handleMucInvite } from "./rooms.js";
 import { handleMucPresence } from "./omemo/muc-occupants.js";
@@ -20,8 +21,10 @@ import { handleMucPresence } from "./omemo/muc-occupants.js";
 export function setupPresenceHandlers(
   xmpp: ReturnType<typeof client>,
   accountId: string,
+  config: XmppConfig,
   log?: Logger
 ): void {
+  const ownerAllowList = normalizeAllowFrom(config.allowFrom);
   xmpp.on("stanza", async (stanza) => {
     if (!stanza.is("presence")) return;
     
@@ -57,17 +60,15 @@ export function setupPresenceHandlers(
     
     // Handle subscription requests - auto-approve
     if (type === "subscribe") {
-      log?.info?.(`[${accountId}] XMPP presence subscribe from ${fromBare} - auto-approving`);
-      
-      // Send subscribed (approve their request)
-      const subscribed = xml("presence", { to: fromBare, type: "subscribed" });
-      await xmpp.send(subscribed);
-      
-      // Also subscribe back to them (mutual subscription)
-      const subscribe = xml("presence", { to: fromBare, type: "subscribe" });
-      await xmpp.send(subscribe);
-      
-      log?.debug?.(`[${accountId}] XMPP sent subscribed + subscribe to ${fromBare}`);
+      if (isSenderAllowed(ownerAllowList, fromBare)) {
+        log?.info?.(`[${accountId}] XMPP presence subscribe from ${fromBare} - approving (owner allowlist)`);
+        const subscribed = xml("presence", { to: fromBare, type: "subscribed" });
+        await xmpp.send(subscribed);
+      } else {
+        log?.warn?.(`[${accountId}] XMPP presence subscribe from ${fromBare} - rejecting (not in allowFrom)`);
+        const unsubscribed = xml("presence", { to: fromBare, type: "unsubscribed" });
+        await xmpp.send(unsubscribed);
+      }
     }
     
     // Handle probe - respond with current presence
@@ -136,8 +137,10 @@ export function setupMucInviteHandler(
   xmpp: ReturnType<typeof client>,
   accountId: string,
   nickname: string,
+  config: XmppConfig,
   log?: Logger
 ): void {
+  const inviteAllowList = normalizeAllowFrom(config.inviteAllowFrom ?? config.allowFrom);
   xmpp.on("stanza", async (stanza) => {
     if (!stanza.is("message")) return;
     
@@ -155,6 +158,11 @@ export function setupMucInviteHandler(
     const inviterJid = bareJid(invite.attrs.from || "");
     const reason = invite.getChildText("reason") || "No reason provided";
     
+    if (!inviterJid || !isSenderAllowed(inviteAllowList, inviterJid)) {
+      log?.warn?.(`[${accountId}] Rejecting MUC invite to ${roomJid} from ${inviterJid || "unknown"} (not in invite allowlist)`);
+      return;
+    }
+
     log?.info?.(`[${accountId}] MUC invite: room=${roomJid} from=${inviterJid} reason="${reason}"`);
     
     await handleMucInvite(xmpp, roomJid, inviterJid, nickname, accountId, log);

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,10 @@ export interface XmppConfig {
   dmAllowlist?: string[];
   /** Allowed sender JIDs for groups (if different from allowFrom) */
   groupAllowFrom?: string[];
+  /** Allowed inviter JIDs for auto-joining MUC invites (defaults to allowFrom) */
+  inviteAllowFrom?: string[];
+  /** Allow SASL PLAIN fallback when stronger mechanisms are unavailable */
+  allowSaslPlain?: boolean;
   /** Group chat rooms to join */
   groups?: string[];
   /** Action configuration (reactions, etc.) */

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,16 @@ export interface XmppActionConfig {
 }
 
 /**
+ * Media security configuration
+ */
+export interface XmppMediaSecurityConfig {
+  /** Allow file:// URLs for local file reads (default: false) */
+  allowFileUrls?: boolean;
+  /** Allowlisted local roots for file reads */
+  allowedLocalPaths?: string[];
+}
+
+/**
  * Tool policy for group tool access control
  */
 export interface XmppToolPolicy {
@@ -52,6 +62,8 @@ export interface XmppOmemoConfig {
   enabled?: boolean;
   /** Device label for this bot instance */
   deviceLabel?: string;
+  /** Maximum devices per JID to encrypt for (default: 10) */
+  maxDevicesPerJid?: number;
 }
 
 /**
@@ -100,6 +112,8 @@ export interface XmppConfig {
   sendReadReceipts?: boolean;
   /** OMEMO encryption configuration */
   omemo?: XmppOmemoConfig;
+  /** Media/file security configuration */
+  media?: XmppMediaSecurityConfig;
   /** Multi-account configuration */
   accounts?: Record<string, XmppConfig>;
 }

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { isSenderAllowed, normalizeAllowFrom } from "../src/normalize.js";
+
+describe("normalizeAllowFrom", () => {
+  it("treats empty lists as deny-all", () => {
+    const normalized = normalizeAllowFrom();
+    expect(normalized).toEqual({ entries: [], hasWildcard: false });
+    expect(isSenderAllowed(normalized, "user@example.com")).toBe(false);
+  });
+
+  it("allows wildcard entries", () => {
+    const normalized = normalizeAllowFrom(["*"]);
+    expect(normalized).toEqual({ entries: [], hasWildcard: true });
+    expect(isSenderAllowed(normalized, "someone@example.com")).toBe(true);
+  });
+
+  it("normalizes prefixes, resources, and casing before matching", () => {
+    const normalized = normalizeAllowFrom(["xmpp:User@Example.com/Device"]);
+    expect(normalized).toEqual({ entries: ["user@example.com"], hasWildcard: false });
+    expect(isSenderAllowed(normalized, "USER@example.com/mobile")).toBe(true);
+  });
+});


### PR DESCRIPTION
- Hardens local media reads with canonical-path allowlists and file:// opt-in behavior.
- Adds media downloader SSRF protections (private IP/DNS blocking, redirect/size/time limits).
- Encrypts OMEMO persistence, tightens trust behavior, and enforces env-reference password handling.
- Hardens allowlist behavior, invite/presence gating, XML reaction parsing, SASL checks, and JID normalization.

Validation:
- npm run build
- npm test -- --run (3 tests passed)
- npm run lint (fails due to missing eslint.config.js with ESLint v9 in current repo setup)

Co-Authored-By: Oz <oz-agent@warp.dev>